### PR TITLE
Set empty autoplay var in header video to prevent undefined notice

### DIFF
--- a/classes/class-normalize-wp.php
+++ b/classes/class-normalize-wp.php
@@ -118,6 +118,8 @@ class normalizeWP {
 		 * Modify YouTube Embed URL	
 		 */
 		public function modify_youtube_embed_url($html) {
+			$autoplay = '';
+			
 			if( get_field('video-popup') ) {
 				$autoplay = '&autoplay=1';
 			}

--- a/wp-normalize.php
+++ b/wp-normalize.php
@@ -2,7 +2,7 @@
 	Plugin Name: WP Normalize
 	Plugin URI: https://github.com/bramwillemse/wp-normalize
 	Description: Set of base functions
-	Version: 1.0.3
+	Version: 1.0.4
 	Author: Bram Willemse
 	Author URI: http://www.bramwillemse.nl
 	Tested up to: 4.6.1


### PR DESCRIPTION
Fix a PHP notice for undefined autoplay variable 
