### PR TITLE
Remove WordPress emoji scripts from head to decrease http requests

### DIFF
--- a/classes/class-normalize-wp.php
+++ b/classes/class-normalize-wp.php
@@ -9,6 +9,8 @@ class normalizeWP {
     public function __construct() {		
 	   	# Scripts
 		add_filter( 'wp_default_scripts', array( &$this, 'dequeue_jquery_migrate' ) ); // Remove jQuery Migrate script
+		remove_action( 'wp_head', 'print_emoji_detection_script', 7 );
+		remove_action( 'wp_print_styles', 'print_emoji_styles' ); 		
 		add_filter( 'style_loader_src',  array( &$this, 't5_remove_version' )); // Remove version numbers from stylesheets
 		add_filter( 'script_loader_src', array( &$this, 't5_remove_version' )); // Remove version numbers from scripts
 		


### PR DESCRIPTION
WordPress automatically adds two emoji scripts. Ridiculous. So I'm getting rid of them once and for all!
